### PR TITLE
display fish data in scrollable list

### DIFF
--- a/src/fish-data-scene.ts
+++ b/src/fish-data-scene.ts
@@ -1,5 +1,6 @@
 import { Container, Text } from 'pixi.js';
 import ConvertCsvToJson from 'convert-csv-to-json';
+import { ScrollBox } from '@pixi/ui';
 
 /*
 *   Fish Data Scene
@@ -8,18 +9,22 @@ import ConvertCsvToJson from 'convert-csv-to-json';
 export const setupFishDataScene = async (container: Container) => {
   const csvText = await loadCSV('data/test-data.csv');
 
-  const jsonData = ConvertCsvToJson.fieldDelimiter(',').csvStringToJson(csvText).slice(0, 5);
-
-  const jsonText = new Text({
-    text: JSON.stringify(jsonData, null, 2),
-    style: {
-      fontFamily: "Arial",
-      fontSize: 12,
-      fill: 0xffffff,
-    },
+  const scrollBox = new ScrollBox({
+    background: 0x000000,
+    width: 900,
+    height: 600,
+    type: 'vertical',
+    items: ConvertCsvToJson.fieldDelimiter(',').csvStringToJson(csvText).map((fishObject: any) => new Text({
+          text: JSON.stringify(fishObject, null, 2),
+          style: {
+            fontFamily: "Arial",
+            fontSize: 14,
+            fill: 0xffffff,
+          },
+        })),
   });
 
-  container.addChild(jsonText);
+  container.addChild(scrollBox);
 };
 
 const loadCSV = async (url: string) => {


### PR DESCRIPTION
previously we couldn't display all the data due to the size of the text element being too large if it contains the entire json. now we put each json object into its own text element and display it in a scrollable list